### PR TITLE
CORENET-709: Delete NNCP CR that defines primary network interface.

### DIFF
--- a/e2e-tests/test_delete_primary_nncp.yml
+++ b/e2e-tests/test_delete_primary_nncp.yml
@@ -1,0 +1,91 @@
+---
+- name: End-to-End Test for delete_primary_nncp module
+  hosts: localhost
+  gather_facts: false
+  vars:
+    test_interface_name: "ens5"  # Replace with the actual primary interface name used in your test env
+    test_nncp_name: "test-primary-nncp"
+
+  tasks:
+
+    - name: Check if NNCP CRD exists
+      command: oc get crd nodenetworkconfigurationpolicies.nmstate.io -o name
+      register: crd_check
+      retries: 5
+      delay: 5
+      until: crd_check.rc == 0 and 'nodenetworkconfigurationpolicies.nmstate.io' in crd_check.stdout
+      changed_when: false
+      failed_when: crd_check.rc != 0
+
+    - name: Debug - Confirm CRD exists
+      debug:
+        msg: "CRD found: {{ crd_check.stdout }}"
+
+    - name: Create dummy NNCP for test
+      copy:
+        dest: "/tmp/{{ test_nncp_name }}.yaml"
+        content: |
+          apiVersion: nmstate.io/v1
+          kind: NodeNetworkConfigurationPolicy
+          metadata:
+            name: {{ test_nncp_name }}
+          spec:
+            desiredState:
+              interfaces:
+              - name: {{ test_interface_name }}
+                type: ethernet
+                state: up
+
+    - name: Apply dummy NNCP
+      command: oc apply -f /tmp/{{ test_nncp_name }}.yaml
+      register: apply_output
+      changed_when: "'created' in apply_output.stdout or 'configured' in apply_output.stdout"
+      failed_when: apply_output.rc != 0
+
+    - name: Ensure the dummy NNCP was created
+      command: oc get nncp {{ test_nncp_name }}
+      register: nncp_get
+      retries: 5
+      delay: 5
+      until: nncp_get.rc == 0
+      changed_when: false
+      failed_when: nncp_get.rc != 0
+
+    - name: Wait for NNCP to be applied successfully
+      command: >
+        oc wait nncp {{ test_nncp_name }} --for=condition=Available --timeout=60s
+      register: wait_result
+      changed_when: false
+      failed_when: wait_result.rc != 0
+
+    - name: Run delete_primary_nncp module
+      delete_primary_nncp:
+        interface_name: "{{ test_interface_name }}"
+      register: delete_result
+
+    - name: Verify deletion module output
+      debug:
+        var: delete_result
+
+    - name: Confirm NNCP is deleted
+      command: oc get nncp {{ test_nncp_name }}
+      register: nncp_deleted
+      retries: 5
+      delay: 5
+      until: nncp_deleted.rc != 0
+      ignore_errors: true
+      failed_when: nncp_deleted.rc == 0
+      changed_when: false
+
+    - name: Assert NNCP was removed
+      assert:
+        that:
+          - delete_result.changed
+          - "'deleted successfully' in delete_result.msg"
+          - nncp_deleted.rc != 0
+        fail_msg: "NNCP deletion did not occur as expected"
+
+    - name: Cleanup temp NNCP file
+      file:
+        path: "/tmp/{{ test_nncp_name }}.yaml"
+        state: absent

--- a/library/delete_primary_nncp.py
+++ b/library/delete_primary_nncp.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python
+
+from ansible.module_utils.basic import AnsibleModule
+import json
+import time
+
+
+def run_command_with_retries(module, command, retries=3, delay=3):
+    for attempt in range(retries):
+        rc, stdout, stderr = module.run_command(command)
+        if rc == 0:
+            return stdout.strip(), None
+        module.warn(f"Attempt {attempt + 1} failed: {stderr.strip()}")
+        time.sleep(delay)
+    return None, f"Command '{' '.join(command)}' failed after {retries} attempts: {stderr.strip()}"
+
+
+def main():
+    module_args = dict(
+        interface_name=dict(type="str", required=True),
+        retries=dict(type="int", default=3),
+        delay=dict(type="int", default=3)
+    )
+
+    module = AnsibleModule(argument_spec=module_args)
+
+    interface_name = module.params["interface_name"]
+    retries = module.params["retries"]
+    delay = module.params["delay"]
+
+    # Step 0: Check if NMState Operator is installed (CRD must exist)
+    check_crd_cmd = ["oc", "get", "crd", "nodenetworkconfigurationpolicies.nmstate.io", "-o", "name"]
+    crd_output, crd_error = run_command_with_retries(module, check_crd_cmd, retries, delay)
+    if crd_error or not crd_output.strip():
+        module.exit_json(
+            changed=False,
+            skipped=True,
+            msg="NMState Operator not installed or NNCP CRD is missing. Skipping deletion."
+        )
+
+    # Step 1: Get list of NNCPs
+    get_command = ["oc", "get", "nncp", "-o", "json"]
+    output, error = run_command_with_retries(module, get_command, retries, delay)
+    if error:
+        module.fail_json(msg=f"Failed to retrieve NNCPs: {error}")
+
+    try:
+        nncp_data = json.loads(output)
+    except json.JSONDecodeError:
+        module.fail_json(msg="Failed to parse NNCP JSON output.")
+
+    target_nncp = None
+    for item in nncp_data.get("items", []):
+        name = item["metadata"]["name"]
+        interfaces = item.get("spec", {}).get("desiredState", {}).get("interfaces", [])
+        for iface in interfaces:
+            if iface.get("name") == interface_name:
+                target_nncp = name
+                break
+        if target_nncp:
+            break
+
+    if not target_nncp:
+        module.exit_json(changed=False, msg=f"No NNCP found for interface '{interface_name}'.")
+
+    # Step 2: Delete the NNCP
+    delete_command = ["oc", "delete", "nncp", target_nncp]
+    _, error = run_command_with_retries(module, delete_command, retries, delay)
+    if error:
+        module.fail_json(msg=f"Failed to delete NNCP '{target_nncp}': {error}")
+
+    module.exit_json(changed=True, msg=f"NNCP '{target_nncp}' deleted successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/migration-playbook.yml
+++ b/migration-playbook.yml
@@ -35,4 +35,5 @@
         #mtu: 1400
         #geneve_port: 6081
         #ipv4_subnet: "100.64.0.0/16"
+        #interface_name: eth0
 

--- a/roles/migration/tasks/main.yml
+++ b/roles/migration/tasks/main.yml
@@ -38,10 +38,26 @@
   debug:
     msg: "{{ result.msg }}"
 
-
 - name: Patch Network.operator.openshift.io and wait for migration field to clear
   clean_migration_field:
     timeout: "{{ clean_migration_timeout }}"
+
+- name: Check if NNCP CRD exists with retries
+  command: oc get crd nodenetworkconfigurationpolicies.nmstate.io -o name
+  register: crd_check
+  retries: 5
+  delay: 5
+  until: crd_check.rc == 0 and 'nodenetworkconfigurationpolicies.nmstate.io' in crd_check.stdout
+  changed_when: false
+  ignore_errors: true
+
+- name: Delete NNCP for primary interface if exists
+  delete_primary_nncp:
+    interface_name: "{{ interface_name }}"
+  when:
+    - interface_name is defined
+    - interface_name | length > 0
+    - nncp_crd_exists
 
 - name: Check if disable auto migration is set
   set_fact:


### PR DESCRIPTION
Check if the interface NodeNetworkConfigurationPolicy (NNCP) custom resource (CR) that defines the primary network interface for the OpenShift SDN network plugin and if yes then Delete the NodeNetworkConfigurationPolicy (NNCP) custom resource (CR) that defines the primary network interface for the OpenShift SDN network plugin